### PR TITLE
Add navigator as ancestor to Offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.14
+
+* Add `navigator.context.findRenderObject()` as ancestor to overlay position offset, this is needed to work correctly inside a RouterOutlet.
+
 ## 0.0.11
 
 * Initial release.

--- a/lib/src/menu_float.dart
+++ b/lib/src/menu_float.dart
@@ -81,8 +81,12 @@ class _MenuFloatState<T> extends State<MenuFloat<T>>
   /// Returns a MenuFloatIdealPosition.
   MenuFloatIdealPosition _getWidgetPositionAndSizeRelativeToWindow(
       BuildContext? menuKeyContext) {
+    final navigator = Navigator.of(context);
     final RenderBox renderBox = menuKeyContext?.findRenderObject() as RenderBox;
-    final position = renderBox.localToGlobal(Offset.zero);
+    final position = renderBox.localToGlobal(
+      Offset.zero, 
+      ancestor: navigator.context.findRenderObject(),
+    );
     final double top = position.dy;
     final double left = position.dx;
     final double width = renderBox.size.width;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: menu_float
 description: A menu float package to use on menu like tooltip, dropdown and etc.
-version: 0.0.13
+version: 0.0.14
 homepage: https://github.com/emirdeliz/menu_float
 
 environment:


### PR DESCRIPTION
Add `navigator.context.findRenderObject()` as an ancestor to position the overlay offset. This is required to work correctly inside a RouterOutlet, the flutter overlay widgets implement this, for example DropdownButton.